### PR TITLE
Add sponsorship page

### DIFF
--- a/public/sponsorship.html
+++ b/public/sponsorship.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css"
+    />
+    <title>NixCon 2025 Sponsorship</title>
+  </head>
+  <body>
+    <main class="container">
+      <h2 id="sponsorshiptiers">Sponsorship tiers</h2>
+
+      <h3 id="donation">Non-sponsorship donation (0+ EUR)</h3>
+
+      <ul>
+        <li>Supporting the conference and official Nix projects</li>
+        <li>Confirmation of donation via OpenCollective</li>
+      </ul>
+
+      <h3 id="bronze">Bronze (1024+ EUR):</h3>
+
+      <ul>
+        <li>Linked logo on the website</li>
+        <li>Linked shout-out or repost from official social media accounts</li>
+        <li>
+          Possibility to distribute your own stickers/swag/merch at the venue
+        </li>
+        <li>
+          Tickets: 1+ corporate tickets<a
+            href="#fn:1"
+            id="fnref:1"
+            title="see footnote"
+            class="footnote"
+            ><sup>1</sup></a
+          >
+        </li>
+      </ul>
+
+      <h3 id="silver">Silver (2048+ EUR):</h3>
+
+      <ul>
+        <li>Everything from Bronze</li>
+        <li>Shout-out in the opening</li>
+        <li>Slot on break slideshow (provide a slide in advance)</li>
+        <li>
+          Possibility to distribute flyers (provide them in advance) to all
+          attendees in bag
+        </li>
+        <li>
+          Tickets: 2+ corporate tickets<a
+            href="#fn:1"
+            title="see footnote"
+            class="footnote"
+            ><sup>1</sup></a
+          >
+        </li>
+      </ul>
+
+      <h3 id="gold">Gold (4096+ EUR):</h3>
+
+      <ul>
+        <li>Everything from Silver</li>
+        <li>5 minute lightning talk slot</li>
+        <li>
+          Dedicated space for a booth<a
+            href="#fn:2"
+            id="fnref:2"
+            title="see footnote"
+            class="footnote"
+            ><sup>2</sup></a
+          >
+        </li>
+        <li>
+          Tickets: 4+ corporate tickets<a
+            href="#fn:1"
+            title="see footnote"
+            class="footnote"
+            ><sup>1</sup></a
+          >
+        </li>
+      </ul>
+
+      <h3 id="diamond">Diamond (8192+ EUR):</h3>
+
+      <ul>
+        <li>Everything from Gold</li>
+        <li>
+          Logo on some official conference swag<a
+            href="#fn:2"
+            title="see footnote"
+            class="footnote"
+            ><sup>2</sup></a
+          >
+          <a href="#fn:3" id="fnref:3" title="see footnote" class="footnote"
+            ><sup>3</sup></a
+          >
+        </li>
+        <li>
+          1 minute presentation slot (provide the slides in advance) in the
+          conference opening
+        </li>
+        <li>Intro of all recordings show your name/logo</li>
+        <li>
+          Possibility to distribute items (provide them in advance) to all
+          attendees in bag
+        </li>
+        <li>
+          Tickets: 8+ corporate tickets<a
+            href="#fn:1"
+            title="see footnote"
+            class="footnote"
+            ><sup>1</sup></a
+          >
+        </li>
+      </ul>
+
+      <h3 id="generalinfo">General info</h3>
+
+      <ul>
+        <li>
+          Sponsors can be tier-limited or rejected by the Nix Steering Committee
+          for any reason.
+        </li>
+        <li>
+          The outline of all sponsor content must be disclosed in advance. We
+          reserve the right to reject content.
+        </li>
+        <li>
+          Visibility priority is given according to tiers and donation amount.
+        </li>
+        <li>The sponsor can selectively abstain from perks.</li>
+        <li>Surplus funds will be used to support official Nix projects.</li>
+        <li>
+          Reach out if you&#8217;d like to sponsor in a more custom way, such as
+          food, drinks, services, equipment, or only specific perks.
+        </li>
+      </ul>
+
+      <h3 id="howtosponsor">How to sponsor</h3>
+
+      <p>
+        Send an email to
+        <a
+          href="mailto:sponsor@nixos.org?subject=NixCon%202025%20sponsorship%20offer&body=Company%20name%3A%0D%0AWebsite%3A%20%0D%0ADesired%20tier%3A%20%0D%0AAdditional%20details%3A%20"
+          >sponsor@nixos.org</a
+        >
+        with:
+      </p>
+
+      <ul>
+        <li>Company name and website</li>
+        <li>Desired tier, amount and perks</li>
+        <li>Any other details</li>
+      </ul>
+
+      <div class="footnotes">
+        <hr />
+        <ol>
+          <li id="fn:1">
+            <p>
+              One corporate ticket per 1024 EUR. Only corporate tickets come
+              with company name/logo recognition on the badge. Corporate tickets
+              can also be bought individually when ticket sales open.
+              <a href="#fnref:1" title="return to body" class="reversefootnote"
+                >&#160;&#8617;&#xfe0e;</a
+              >
+            </p>
+          </li>
+
+          <li id="fn:2">
+            <p>
+              These perks may be limited in availability.
+              <a href="#fnref:2" title="return to body" class="reversefootnote"
+                >&#160;&#8617;&#xfe0e;</a
+              >
+            </p>
+          </li>
+
+          <li id="fn:3">
+            <p>
+              These perks require production and cannot be guaranteed if too
+              late.
+              <a href="#fnref:3" title="return to body" class="reversefootnote"
+                >&#160;&#8617;&#xfe0e;</a
+              >
+            </p>
+          </li>
+        </ol>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
This is only the content.
The design team can integrate it with the proper styling.

As discussed at the meeting on the 2025-04-14 it would be good if these page doesn't show the moving lava lamp but maybe a static image of it or similar.

https://pad.lassul.us/POnY9iVgQWG7HqFpR6T_nA